### PR TITLE
fix issue #5

### DIFF
--- a/src/main/java/org/vaddon/CustomMediaQuery.java
+++ b/src/main/java/org/vaddon/CustomMediaQuery.java
@@ -25,7 +25,8 @@ public class CustomMediaQuery extends PolymerTemplate<CustomMediaQuery.CustomMed
 
     public CustomMediaQuery(Consumer<Boolean> action) {
         this.action = action;
-        getModel().setQuerymatches(true);
+        getElement().addSynchronizedProperty("querymatches");
+        getElement().addSynchronizedPropertyEvent("querymatches");
         getElement().addPropertyChangeListener("querymatches", e->
         {
             action.accept(getModel().getQuerymatches());
@@ -34,7 +35,6 @@ public class CustomMediaQuery extends PolymerTemplate<CustomMediaQuery.CustomMed
 
     public void setQuery(String query) {
         getModel().setQuery(query);
-        action.accept(getModel().getQuerymatches());
     }
 
     public void setQuery(MediaQuery query){

--- a/src/main/resources/META-INF/resources/frontend/org/vaadon/custom-media-query.html
+++ b/src/main/resources/META-INF/resources/frontend/org/vaadon/custom-media-query.html
@@ -16,7 +16,6 @@
                 return 'custom-media-query'
             }
 
-
             static get properties() {
                 return {
 
@@ -32,11 +31,19 @@
                      * The CSS media query to evaluate.
                      */
                     query: {
-                        type: String
+                        type: String,
+                        notify: true
                     }
                 }
             }
+            ready() {
+                this.addEventListener('query-changed', function (ev) {
+                    this.dispatchEvent(new CustomEvent('querymatches', {}));
+                });
+                super.ready();
+            }
         }
+
         customElements.define(CustomMediaQuery.is, CustomMediaQuery);
     </script>
 </dom-module>


### PR DESCRIPTION
This PR fixes issue #5. By adding an eventlister on the client side before `ready` to the `query` property. When the property `query` is changed from the server-side a `querymatches`  event will be triggerd, to force the server to update the property value on the server side.  